### PR TITLE
fix: Android Studio 4.1 can't import Android lib syntax error

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,4 @@ org.gradle.jvmargs=-Xmx2048m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
+kotlin.mpp.enableGranularSourceSetsMetadata=true


### PR DESCRIPTION
refer to [stackoverflow](kotlin.mpp.enableGranularSourceSetsMetadata=true)